### PR TITLE
Disable building lz4 tool

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -10,11 +10,16 @@ share {
   );
   plugin Extract => 'tar.gz';
   plugin 'Build::CMake';
+  # Disable building `lz4` tool for now as it is dynamically linked by default
+  # by the CMake build.
+  my $build_tool = 0;
   build [
     ['%{cmake}',
       @{ meta->prop->{plugin_build_cmake}->{args} },
 
-      qw(-DLZ4_BUILD_CLI=ON),     # tool
+      (
+        qw(-DLZ4_BUILD_CLI=ON),     # tool
+      )x!!( $build_tool ),
       qw(-DBUILD_STATIC_LIBS=ON), # xs
       qw(-DBUILD_SHARED_LIBS=ON), # ffi
 

--- a/t/alien_lz4.t
+++ b/t/alien_lz4.t
@@ -6,9 +6,11 @@ use Alien::LZ4;
 alien_diag 'Alien::LZ4';
 alien_ok 'Alien::LZ4';
 
+if(0) { # not building lz4 for now
 run_ok([ qw(lz4 --version) ])
   ->success
   ->out_like(qr/LZ4 command line interface/);
+}
 
 my $xs = <<'END';
 #include "EXTERN.h"


### PR DESCRIPTION
The current CMake build makes `bin/lz4` dynamically linked on share
install. There is a way to fix this either by making it statically
linked (larger file) or modifying the search path to the dynamic
library.
