### PR TITLE
Set bugtracker to GitHub

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,7 @@ revision = 5
 [AlienBuild]
 [CheckChangesHasContent]
 [GithubMeta]
+issues = 1
 [ReadmeAnyFromPod]
 type = markdown
 location = root


### PR DESCRIPTION
I noticed that the report for #4 came in through rt.  Should we use GitHub for the issue tracker? 